### PR TITLE
Fixed missing var

### DIFF
--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -7,7 +7,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-ADTypes = {
+var ADTypes = {
     flags : { typeFlag : 0x01, resolve: intArrayToByte },
     incompleteUUID16 : { typeFlag : 0x02, resolve: octetStringArrayToBuffer },
     completeUUID16 : { typeFlag : 0x03, resolve: octetStringArrayToBuffer },


### PR DESCRIPTION
V8 in `electron@7.1.2` throws a `ReferenceError` attempting to run this since `ADTypes` is not declared anywhere. Fixed.