### PR TITLE
Handling raw data obtained from Android's ScanRecord.getBytes

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -10,10 +10,10 @@
 var Packet = require('./packet').Packet;
 
 // Expects payload to be a buffer
-function split(payload) {
+function split(payload, {noPayloadLength} = {}) {
   var splits = [];
   var i = 0;
-  var length = payload[i++];
+  var length = noPayloadLength ? payload.length : payload[i++];
 
   while (i < length) {
     // Grab the length of the entire packet
@@ -35,7 +35,7 @@ function split(payload) {
   return splits;
 }
 
-function parse(buffer, byteOrder, callback) {
+function parse(buffer, byteOrder, callback, {noPayloadLength} = {}) {
 
   // If a byte order wasn't passed it, make it big endian by default
   byteOrder = byteOrder ? byteOrder : "BE";
@@ -53,7 +53,7 @@ function parse(buffer, byteOrder, callback) {
   }
 
   // Split up the payload into packet chunks
-  var splits = split(buffer);
+  var splits = split(buffer, {noPayloadLength});
 
   var packets = [];
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -18,6 +18,8 @@ function split(payload, {noPayloadLength} = {}) {
   while (i < length) {
     // Grab the length of the entire packet
     var packetLength = payload[i++];
+    if (packetLength == 0)
+      continue;
     // Grab the kind of packet
     var type = payload[i++];
     // The length of the data is the whole thing minus the type byte

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -19,7 +19,7 @@ function split(payload, {noPayloadLength} = {}) {
     // Grab the length of the entire packet
     var packetLength = payload[i++];
     if (packetLength == 0)
-      continue;
+      break;
     // Grab the kind of packet
     var type = payload[i++];
     // The length of the data is the whole thing minus the type byte

--- a/test/parser-spec.js
+++ b/test/parser-spec.js
@@ -25,6 +25,11 @@ describe("Parser", function() {
         var parsed = parser.parse(testPayload);
         expect(parsed.length).to.equal(3);
     });
+    it ("should fetch the first length octet when noPayloadLength is true", function() {
+        var newPayload = new Buffer([ 2, 1, 6, 3, 2, 160, 255 ]);
+        var parsed = parser.parse(newPayload, null, null, {noPayloadLength: true});
+        expect(parsed.length).to.equal(2);
+    });
     it("should properly parse a payload into the correct kinds of data", function() {
         var parsed = parser.parse(testPayload);
         parsed.forEach(function(packet) {

--- a/test/parser-spec.js
+++ b/test/parser-spec.js
@@ -18,6 +18,13 @@ describe("Parser", function() {
     it("should split up an advertisement packet into distinct data formats", function() {
       expect(parser.split(testPayload).length).to.equal(3);
     });
+
+    it("should discard the following data assuming them zero-padding when the leading-length octet of AD structure was 0x00.", function() {
+        var newPayload = Buffer.from(testPayload);
+        // Set the length of second AD structure to zero.
+        newPayload[4] = 0x00;
+        expect(parser.split(newPayload).length).to.equal(1);
+    });
   });
 
   describe("#parse()", function() {
@@ -25,7 +32,7 @@ describe("Parser", function() {
         var parsed = parser.parse(testPayload);
         expect(parsed.length).to.equal(3);
     });
-    it ("should fetch the first length octet when noPayloadLength is true", function() {
+    it ("should parse the entire buffer when noPayloadLength is true, assuming the payload not to have the leading length octet.", function() {
         var newPayload = new Buffer([ 2, 1, 6, 3, 2, 160, 255 ]);
         var parsed = parser.parse(newPayload, null, null, {noPayloadLength: true});
         expect(parsed.length).to.equal(2);


### PR DESCRIPTION
Thanks for providing the nice library. 

I have utilized the lib to analyze the raw AdvData obtained from [android.bluetooth.le.ScanRecord.getBytes](https://developer.android.com/reference/android/bluetooth/le/ScanRecord#getBytes()).

To fit that purpose without any modification of input, I propose two changes on `parse()` and `split()`:

- Handle the trailing zero-padding bytes.
- Add `noPayloadLength` option as the 4th parameter of `parse()`.

## Example of data from android.bluetooth.le.ScanRecord.getBytes

```
1a ff 4c 00 02 15 50 76 5c b7 d9 ea 4e 21 99 a4 fa 87 96 13 a4 92 b2 c9 64 d1 ce 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
(iBeacon)
```

